### PR TITLE
Code refactored for docker compose warning and singleton implementation of elastic.client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   elasticsearch01:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2

--- a/src/client/elasticsearch.ts
+++ b/src/client/elasticsearch.ts
@@ -1,13 +1,21 @@
 import elasticsearch from "elasticsearch"
 
-function getClient() {
-    // The `log: "trace"` attribute will show Elastic Client log.
-    const client = new elasticsearch.Client({
-        host: "localhost:9200",
-        //log: "trace"
-    })
+class elasticClient {
+    private static instance: elasticsearch.Client
+    private constructor() {}
 
-    return client
+    public static getInstance(): elasticsearch.Client {
+        if (!elasticClient.instance) {
+            elasticClient.instance = new elasticsearch.Client({
+                host: "localhost:9200",
+                //log: "trace"
+            })
+        }
+        return elasticClient.instance
+    }
 }
 
+function getClient(): elasticsearch.Client {
+    return elasticClient.getInstance()
+}
 export default getClient


### PR DESCRIPTION
1. Removed version specification from docker.compose as it was giving warning as version is deprecated.
2. Made getClient() method return singleton instance of  elastic.client for better memory management